### PR TITLE
refactor: 삭제된 DidEndDeletingDelegate 구현

### DIFF
--- a/ProjectManager/ProjectManager/Source/Domain/UseCases/Delegate/DidEndEditingTaskDelegate.swift
+++ b/ProjectManager/ProjectManager/Source/Domain/UseCases/Delegate/DidEndEditingTaskDelegate.swift
@@ -13,5 +13,10 @@ protocol DidEndUpdatingDelegate: AnyObject {
     func didEndUpdating(task: Task)
 }
 
+protocol DidEndDeletingDelegate: AnyObject {
+    func didEndDeleting(task: Task)
+}
+
 protocol DidEndEditingTaskDelegate: DidEndCreatingTaskDelegate,
-                                    DidEndUpdatingDelegate { }
+                                    DidEndUpdatingDelegate,
+                                    DidEndDeletingDelegate{ }

--- a/ProjectManager/ProjectManager/Source/Domain/UseCases/DeleteTaskUseCase.swift
+++ b/ProjectManager/ProjectManager/Source/Domain/UseCases/DeleteTaskUseCase.swift
@@ -8,13 +8,15 @@
 import RxSwift
 
 final class DeleteTaskUseCase {
+    private weak var delegate: DidEndDeletingDelegate?
     private let repository: TaskRepository
 
     private let translater = Translater()
     private let disposeBag = DisposeBag()
     let isDeletedSuccess = PublishSubject<Bool>()
 
-    init(repository: TaskRepository) {
+    init(delegate: DidEndDeletingDelegate, repository: TaskRepository) {
+        self.delegate = delegate
         self.repository = repository
     }
 
@@ -25,6 +27,9 @@ final class DeleteTaskUseCase {
 
         repository.delete(entity)
             .subscribe(onNext: { [weak self] isSuccess in
+                if isSuccess {
+                    self?.delegate?.didEndDeleting(task: task)
+                }
                 self?.isDeletedSuccess.onNext(isSuccess)
             })
             .disposed(by: disposeBag)

--- a/ProjectManager/ProjectManager/Source/Domain/UseCases/FetchTasksUseCase.swift
+++ b/ProjectManager/ProjectManager/Source/Domain/UseCases/FetchTasksUseCase.swift
@@ -48,4 +48,14 @@ extension FetchTasksUseCase: DidEndEditingTaskDelegate {
         tasksList[index] = task
         tasks.onNext(tasksList)
     }
+    
+    func didEndDeleting(task: Task) {
+        guard var tasksList = try? tasks.value(),
+              let index = tasksList.firstIndex(where: { $0.id == task.id }) else {
+            return
+        }
+        
+        tasksList.remove(at: index)
+        tasks.onNext(tasksList)
+    }
 }

--- a/ProjectManager/ProjectManagerUnitTests/UseCaseTests/DeleteTaskUseCaseTests.swift
+++ b/ProjectManager/ProjectManagerUnitTests/UseCaseTests/DeleteTaskUseCaseTests.swift
@@ -9,6 +9,12 @@ import XCTest
 
 import RxSwift
 
+private final class DidEndDeletingDelegateStub: DidEndDeletingDelegate {
+    func didEndDeleting(task: Task) {
+        return
+    }
+}
+
 final class DeleteTaskUseCaseTests: XCTestCase {
     var taskRepositoryMock: MockTaskRepository!
     var usecase: DeleteTaskUseCase!
@@ -17,6 +23,7 @@ final class DeleteTaskUseCaseTests: XCTestCase {
     override func setUpWithError() throws {
         taskRepositoryMock = MockTaskRepository(taskEntities: TaskEntityDummy.dummys)
         usecase = DeleteTaskUseCase(
+            delegate: DidEndDeletingDelegateStub(),
             repository: taskRepositoryMock
         )
         disposeBag = DisposeBag()

--- a/ProjectManager/ProjectManagerUnitTests/UseCaseTests/FetchTasksUseCaseTests.swift
+++ b/ProjectManager/ProjectManagerUnitTests/UseCaseTests/FetchTasksUseCaseTests.swift
@@ -124,4 +124,57 @@ final class FetchTasksUseCaseTests: XCTestCase {
         guard let currentTask = tasksList?.first else { return XCTFail() }
         XCTAssertEqual(previousTask.state, currentTask.state)
     }
+    
+    func test_when_deleting_task_is_successful_then_renewing_tasksList_is_successful() {
+        let deleteTaskUseCaseStub = DeleteTaskUseCase(delegate: usecase,
+                                                      repository: taskRepositoryMock)
+        var tasksList: [Task]? = nil
+        usecase.tasks
+            .subscribe(onNext: { tasks in
+                tasksList = tasks
+            })
+            .disposed(by: dispose)
+        
+        usecase.fetchTasks()
+        XCTAssertNotNil(tasksList)
+        
+        guard let previousFirstTask = tasksList?.first else {
+            return XCTFail()
+        }
+        
+        deleteTaskUseCaseStub.deleteTask(previousFirstTask)
+        
+        guard let currentFirstTask = tasksList?.first else { return XCTFail() }
+        XCTAssertNotEqual(currentFirstTask.id, previousFirstTask.id)
+    }
+    
+    func test_when_deleting_task_is_failed_then_tasksList_is_not_renewed() {
+        let deleteTaskUseCaseStub = DeleteTaskUseCase(delegate: usecase,
+                                                      repository: taskRepositoryMock)
+        var tasksList: [Task]? = nil
+        usecase.tasks
+            .subscribe(onNext: { tasks in
+                tasksList = tasks
+            })
+            .disposed(by: dispose)
+        
+        usecase.fetchTasks()
+        XCTAssertNotNil(tasksList)
+        
+        guard let previousFirstTask = tasksList?.first else {
+            return XCTFail()
+        }
+        
+        let targetTask = Task(id: .init(),
+                              title: .init(),
+                              content: .init(),
+                              deadLine: .init(),
+                              state: .done,
+                              isExpired: false)
+        
+        deleteTaskUseCaseStub.deleteTask(targetTask)
+        
+        guard let currentFirstTask = tasksList?.first else { return XCTFail() }
+        XCTAssertEqual(currentFirstTask.id, previousFirstTask.id)
+    }
 }


### PR DESCRIPTION
#### 구현 사항
- FetchTasksUseCase didEndEditTaskDelegate 채택
- FetchTasksUseCase delete도 Test Case 추가

추가적으로 Unit Test부분이 ViewModel 테스트를 구현한 것 같네요.
ViewModel구현하면서 수정하겠습니다.